### PR TITLE
Update the name of the repo to offthecob-platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Offthecob Platform
 ============
 This project contains a series of best practices around managing dependencies and building
 code for the JVM. For examples of this ecosystem, check out the 
-[offthecob-platform-examples](https://github.com/whodevil/offthecob-platform-examples) repository.
+[Offthecob Platform Examples](https://github.com/whodevil/offthecob-platform-examples) repository.
 
 # Catalog
 Produces an artifact containing the library versions maintained in `gradle/libs.versions.toml`.

--- a/bom/bom.gradle.kts
+++ b/bom/bom.gradle.kts
@@ -17,7 +17,7 @@ configure<PublishingExtension> {
             pom {
                 name.set("bom")
                 description.set("Bill of Materials (BOM) for info.offthecob.platform")
-                url.set("https://github.com/whodevil/jvm-platform")
+                url.set("https://github.com/whodevil/offthecob-platform")
                 licenses {
                     license {
                         name.set("The MIT License")
@@ -32,9 +32,9 @@ configure<PublishingExtension> {
                     }
                 }
                 scm {
-                    connection.set("scm:git:git://github.com/whodevil/jvm-platform.git")
-                    developerConnection.set("scm:git:ssh://github.com:whodevil/jvm-platform.git")
-                    url.set("https://github.com/whodevil/jvm-platform/tree/master")
+                    connection.set("scm:git:git://github.com/whodevil/offthecob-platform.git")
+                    developerConnection.set("scm:git:ssh://github.com:whodevil/offthecob-platform.git")
+                    url.set("https://github.com/whodevil/offthecob-platform/tree/master")
                 }
             }
         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ subprojects {
         repositories {
             maven {
                 name = "GitHubPackages"
-                url = uri("https://maven.pkg.github.com/whodevil/jvm-platform")
+                url = uri("https://maven.pkg.github.com/whodevil/offthecob-platform")
                 credentials {
                     username = project.findProperty("gpr.user") as String? ?: System.getenv("USERNAME")
                     password = project.findProperty("gpr.key") as String? ?: System.getenv("GITHUB_TOKEN")

--- a/catalog/catalog.gradle.kts
+++ b/catalog/catalog.gradle.kts
@@ -16,7 +16,7 @@ configure<PublishingExtension> {
             pom {
                 name.set("Catalog")
                 description.set("Gradle version catalog supporting info.offthecob.platform")
-                url.set("https://github.com/whodevil/jvm-platform")
+                url.set("https://github.com/whodevil/offthecob-platform")
                 licenses {
                     license {
                         name.set("The MIT License")
@@ -31,9 +31,9 @@ configure<PublishingExtension> {
                     }
                 }
                 scm {
-                    connection.set("scm:git:git://github.com/whodevil/jvm-platform.git")
-                    developerConnection.set("scm:git:ssh://github.com:whodevil/jvm-platform.git")
-                    url.set("https://github.com/whodevil/jvm-platform/tree/master")
+                    connection.set("scm:git:git://github.com/whodevil/offthecob-platform.git")
+                    developerConnection.set("scm:git:ssh://github.com:whodevil/offthecob-platform.git")
+                    url.set("https://github.com/whodevil/offthecob-platform/tree/master")
                 }
             }
         }

--- a/common/common.gradle.kts
+++ b/common/common.gradle.kts
@@ -18,7 +18,7 @@ configure<PublishingExtension> {
             pom {
                 name.set("Common")
                 description.set("Common library supporting info.offthecob.platform")
-                url.set("https://github.com/whodevil/jvm-platform")
+                url.set("https://github.com/whodevil/offthecob-platform")
                 licenses {
                     license {
                         name.set("The MIT License")
@@ -33,9 +33,9 @@ configure<PublishingExtension> {
                     }
                 }
                 scm {
-                    connection.set("scm:git:git://github.com/whodevil/jvm-platform.git")
-                    developerConnection.set("scm:git:ssh://github.com:whodevil/jvm-platform.git")
-                    url.set("https://github.com/whodevil/jvm-platform/tree/master")
+                    connection.set("scm:git:git://github.com/whodevil/offthecob-platform.git")
+                    developerConnection.set("scm:git:ssh://github.com:whodevil/offthecob-platform.git")
+                    url.set("https://github.com/whodevil/offthecob-platform/tree/master")
                 }
             }
         }

--- a/plugins/plugins.gradle.kts
+++ b/plugins/plugins.gradle.kts
@@ -24,19 +24,22 @@ group = "info.offthecob"
 version = System.getenv("REVISION") ?: "SNAPSHOT"
 
 gradlePlugin {
-    website.set("https://github.com/whodevil/jvm-platform")
-    vcsUrl.set("https://github.com/whodevil/jvm-platform.git")
+    website.set("https://github.com/whodevil/offthecob-platform")
+    vcsUrl.set("https://github.com/whodevil/offthecob-platform.git")
     plugins {
         create("base") {
             id = "info.offthecob.Base"
             implementationClass = "info.offthecob.gradle.BasePlugin"
             tags.set(listOf("kotlin", "java", "groovy", "conventions"))
-            displayName = "Offthecob JVM Base"
+            displayName = "Offthecob Base"
             description =
                 """
                 This plugin contains a bunch of best practices around how to build projects for the JVM.
                 This includes dependency locking by default, kotlin support, groovy support (for testing), 
                 wiring up the junit platform, null away, and linting.
+                
+                The Base plugin also offers a task to help update lock files:
+                ./gradlew resolveAndLockAll --write-locks
                 """.trimIndent()
 
         }

--- a/plugins/plugins.gradle.kts
+++ b/plugins/plugins.gradle.kts
@@ -47,7 +47,7 @@ gradlePlugin {
             id = "info.offthecob.Service"
             implementationClass = "info.offthecob.gradle.ServicePlugin"
             tags.set(listOf("kotlin", "java", "groovy", "conventions", "jib", "containers"))
-            displayName = "Offthecob JVM Service"
+            displayName = "Offthecob Service"
             description =
                 """
                 This plugin contains all the work from 'info.offthecob.Base' but includes 'jib' for building
@@ -58,7 +58,7 @@ gradlePlugin {
             id = "info.offthecob.Library"
             implementationClass = "info.offthecob.gradle.LibraryPlugin"
             tags.set(listOf("kotlin", "java", "groovy", "conventions", "library"))
-            displayName = "Offthecob JVM Library"
+            displayName = "Offthecob Library"
             description =
                 """
                 This plugin contains all the work from 'info.offthecob.Base' but includes 'java-library' for
@@ -69,7 +69,7 @@ gradlePlugin {
             id = "info.offthecob.SpringService"
             implementationClass = "info.offthecob.gradle.SpringService"
             tags.set(listOf("kotlin", "java", "groovy", "conventions", "jib", "containers", "spring"))
-            displayName = "Offthecob JVM Spring Service"
+            displayName = "Offthecob Spring Service"
             description =
                 """
                 This plugin contains all the work from 'info.offthecob.Service' but includes customization of

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,14 +12,11 @@ toolchainManagement {
     }
 }
 
-rootProject.name = "jvm-platform"
+rootProject.name = "offthecob-platform"
 
 dependencyResolutionManagement {
     repositories {
         mavenCentral()
-        maven {
-            url = uri("https://jitpack.io")
-        }
     }
 }
 


### PR DESCRIPTION
jvm-platform was really generic, so after some pondering, considering it's under the group name info.offthecob, it made more sense to call it the offthecob platform.