### PR TITLE
Begin updating usage of foojay resolver

### DIFF
--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,15 +1,5 @@
 plugins {
-    id("org.gradle.toolchains.foojay-resolver")
-}
-
-toolchainManagement {
-    jvm {
-        javaRepositories {
-            repository("foojay") {
-                resolverClass.set(org.gradle.toolchains.foojay.FoojayToolchainResolver::class.java)
-            }
-        }
-    }
+    id("org.gradle.toolchains.foojay-resolver-convention")
 }
 
 dependencyResolutionManagement {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,15 +1,5 @@
 plugins {
-    id("org.gradle.toolchains.foojay-resolver") version "0.7.0"
-}
-
-toolchainManagement {
-    jvm {
-        javaRepositories {
-            repository("foojay") {
-                resolverClass.set(org.gradle.toolchains.foojay.FoojayToolchainResolver::class.java)
-            }
-        }
-    }
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
 }
 
 rootProject.name = "offthecob-platform"


### PR DESCRIPTION
This is the first part of #128. The project needs to use the new plugin, then the plugins can adopt it.